### PR TITLE
.getTotalSecondes() au lieu .totalSecondes

### DIFF
--- a/syllabus/oo.tex
+++ b/syllabus/oo.tex
@@ -303,19 +303,19 @@
 			\EndMethod
 		\Empty
 			\Method{ajouter}{autreDurée~: Durée}{}
-				\Let totalSecondes \Gets totalSecondes + autreDurée.totalSecondes
+				\Let totalSecondes \Gets totalSecondes + autreDurée.getTotalSecondes()
 			\EndMethod
 		\Empty
 			\Method{différence}{autreDurée~: Durée}{Durée}
-				\Return \K{nouvelle} Durée(valeurAbsolue(totalSecondes - autreDurée.totalSecondes))
+				\Return \K{nouvelle} Durée(valeurAbsolue(totalSecondes - autreDurée.getTotalSecondes()))
 			\EndMethod
 		%\Empty
 			%\Method{égale}{autreDurée~: Durée}{booléen}
-				%\Return totalSecondes = autreDurée.totalSecondes
+				%\Return totalSecondes = autreDurée.getTotalSecondes()
 			%\EndMethod
 		\Empty
 			\Method{plusPetit}{autreDurée~: Durée}{booléen}
-				\Return totalSecondes < autreDurée.totalSecondes
+				\Return totalSecondes < autreDurée.getTotalSecondes()
 			\EndMethod
 		\end{LDA}
 	


### PR DESCRIPTION
Lorsque l'objet est reçu en paramètre, et puisque les attributs sont déclarés privés, je trouve qu'il est plus naturel d'utiliser les accesseurs, y compris s'il s'agit de la même classe.

WDYT ?